### PR TITLE
linux/driver: Fix uaccess.h include

### DIFF
--- a/kernel/linux/driver/driver.c
+++ b/kernel/linux/driver/driver.c
@@ -5,7 +5,6 @@
 #include <linux/string.h>
 #include <linux/device.h>
 #include <linux/cdev.h>
-#include <asm/uaccess.h>
 #include <linux/uaccess.h>
 #include <lua/lua.h>
 #include <lua/lualib.h>


### PR DESCRIPTION
On some kernel versions and platforms you can't include asm/uaccess.h
directly. linux/uaccess.h includes it anyway, so it was unnecessary.